### PR TITLE
Fixes issue #15 - Internal Server Error if Authorization header does not exist

### DIFF
--- a/backend/src/routers/public/authentication.ts
+++ b/backend/src/routers/public/authentication.ts
@@ -13,25 +13,28 @@ export async function expressAuthentication(
     // Get API key from request
     const apiKeyStr = request.headers.authorization || request.query["api_key"];
 
-    const apiKeyParsed = z.string().parse(apiKeyStr);
-    const apiKey = await prisma.apiKey.findUnique({
-      where: { key: apiKeyParsed },
-      select: { userId: true },
-    });
-
-    // Check if the API key is valid
-    if (apiKey) {
-      return Promise.resolve({
-        id: apiKey.userId,
+    //Check if api key is present, otherwise return 401
+    if(apiKeyStr != undefined) {
+      const apiKeyParsed = z.string().parse(apiKeyStr);
+      const apiKey = await prisma.apiKey.findUnique({
+        where: { key: apiKeyParsed },
+        select: { userId: true },
       });
-    } else {
-      response
+
+      // Check if the API key is valid
+      if (apiKey) {
+        return Promise.resolve({
+          id: apiKey.userId,
+        });
+      }
+    }
+
+    response
         .status(401)
         .send({
           error: "unauthorized",
           details: "Invalid API key",
         } satisfies ResponseError<"unauthorized">);
-      return Promise.reject({});
-    }
+    return Promise.reject({});
   }
 }


### PR DESCRIPTION
This pull request fixes error #15, I just added an additional If condition that handles if the apiKeyStr is defined. If this is not the case, a 401 unauthorized is returned. For better readability, I have moved the existing logic into the new If statement and moved the existing logic outside. If the authorization is successful, the error is not reached due to an earlier return. If either the API key is not present or incorrect, it is not returned and the response is modified.